### PR TITLE
Set up GitHub Pages deployment for mattmayo.com

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: withastro/action@v3
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,4 +2,6 @@
 import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
-export default defineConfig({});
+export default defineConfig({
+  site: 'https://mattmayo.com',
+});

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+mattmayo.com


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow that builds with Astro and deploys to GitHub Pages on every push to `main`
- Set `site: https://mattmayo.com` in `astro.config.mjs`
- Add `public/CNAME` for the `mattmayo.com` custom domain

## Test plan
- [x] `astro build` succeeds locally and copies `CNAME` into `dist/`
- [ ] After merge, enable GitHub Pages in repo settings with source "GitHub Actions" (one-time setup)
- [ ] Point `mattmayo.com` DNS at GitHub Pages (A/AAAA records or CNAME to `mattmayo.github.io`, per GitHub's custom domain docs)
- [ ] Confirm workflow run succeeds and site is live at mattmayo.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)