### PR TITLE
Fix Node version in Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
       - uses: withastro/action@v3
 
   deploy:


### PR DESCRIPTION
## Summary
- The Pages deploy workflow (PR #70) failed because `ubuntu-latest` defaults to Node 20, but Astro 7 requires Node >=22.12.0
- Add `actions/setup-node@v4` pinned to Node 22 before the build step

## Test plan
- [x] Confirmed the previous run's failure log showed `Node.js v20.20.2 is not supported by Astro!`
- [ ] After merge, confirm the workflow run succeeds and mattmayo.com serves the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)