### PR TITLE
Fix Node version override in Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,10 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: withastro/action@v3
         with:
           node-version: 22
-      - uses: withastro/action@v3
 
   deploy:
     needs: build


### PR DESCRIPTION
## Summary
- PR #71's fix didn't work: `withastro/action@v3` runs its own internal `setup-node` step (defaulting to Node 20) *after* any setup-node step already in the workflow, silently overriding it
- Pass `node-version: 22` as an input to `withastro/action@v3` directly instead of using a separate `actions/setup-node` step

## Test plan
- [x] Confirmed via workflow logs that the standalone setup-node step installed Node 22, but `withastro/action` then ran its own setup-node with `node-version: 20`, downgrading it
- [ ] After merge, confirm the workflow run succeeds and mattmayo.com serves the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)