### PR TITLE
Update DrumWave title to Senior Engineering Manager

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,7 +15,7 @@ import headshot from "../assets/headshot.jpg";
     />
     <div class="intro">
       <h1>Matt Mayo</h1>
-      <p class="role">Engineering Manager at DrumWave, based in Palo Alto, California.</p>
+      <p class="role">Senior Engineering Manager at DrumWave, based in Palo Alto, California.</p>
       <p class="bio">I build and lead teams that ship fintech, fraud, and infrastructure systems at scale.</p>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- Updates the homepage role line from "Engineering Manager at DrumWave" to "Senior Engineering Manager at DrumWave"

## Test plan
- [ ] Visually verify the role line on the homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)