### PR TITLE
Redesign homepage as retro terminal interface

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -15,6 +15,12 @@ const { title } = Astro.props;
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width" />
     <meta name="generator" content={Astro.generator} />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=VT323&family=Share+Tech+Mono&display=swap"
+      rel="stylesheet"
+    />
     <title>{title}</title>
   </head>
   <body>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,233 +2,265 @@
 import Layout from "../layouts/Layout.astro";
 import { Image } from "astro:assets";
 import headshot from "../assets/headshot.jpg";
+
+const experience = [
+  {
+    slug: "drumwave",
+    company: "DrumWave",
+    detail:
+      "Started as a technical lead on a single 3-engineer team, then moved into managing two teams totaling 13 developers. Leading the build of the core consumer and business experience from 0 to 1.",
+  },
+  {
+    slug: "hipcamp",
+    company: "Hipcamp",
+    detail:
+      "Led globally distributed Host experience engineering teams across the US and UK, spanning 3 teams, 10 engineers, and 2 managers. Shipped a new checkout experience and new tooling and integrations for professional campgrounds, including an updated data model to support it. Promoted 2 engineers and moved one into management.",
+  },
+  {
+    slug: "affirm",
+    company: "Affirm",
+    detail:
+      "Led fraud detection for buy now, pay later loans; launched fraud systems into new markets including Australia. Grew the team from 5 to 11 while increasing diversity.",
+  },
+  {
+    slug: "carta",
+    company: "Carta",
+    detail:
+      "Led internal tools and a globally distributed team spanning San Francisco, Toronto, Brazil, and Belarus, including remote hiring and ramp-up across multiple contracting groups. Drove technical design across billing and contract-generation systems.",
+  },
+  {
+    slug: "ebay",
+    company: "eBay",
+    detail:
+      "Owned a full-stack domain end to end, from data storage through back-end services to front end, deployed on Google Cloud. Led a specialized web shopping experience for the China market and helped set the bar for front-end hiring org-wide.",
+  },
+  {
+    slug: "fivestars",
+    company: "FiveStars",
+    detail:
+      "Took the FiveStars iOS app from solo project to a team effort, shipping an industry-first check-in experience using Apple's iBeacon framework. Brought the app from a 1-star to 4+ star rating while holding a 99.9% crash-free rate.",
+  },
+  {
+    slug: "paypal",
+    company: "PayPal",
+    detail:
+      "Led a team of nine engineers to re-platform PayPal's customer-facing reporting infrastructure onto a multi-data-center design serving a 100M+ customer base.",
+  },
+];
 ---
 
 <Layout title="Matt Mayo">
-  <section class="hero">
-    <Image
-      src={headshot}
-      alt="Matt Mayo"
-      width={320}
-      height={320}
-      class="photo"
-    />
-    <div class="intro">
-      <h1>Matt Mayo</h1>
-      <p class="role">Senior Engineering Manager at DrumWave, based in Palo Alto, California.</p>
-      <p class="bio">
-        I build and lead engineering teams that ship fraud detection and infrastructure systems
-        at scale &mdash; from BNPL fraud platforms to globally distributed engineering orgs
-        spanning multiple clouds. I stay hands-on: designing systems, reviewing code, and working
-        directly alongside the teams I lead.
-      </p>
-      <div class="links">
-        <a href="https://www.linkedin.com/in/mayomatt/" target="_blank" rel="noopener">LinkedIn</a>
+  <div class="screen">
+    <div class="scanlines"></div>
+
+    <p class="banner">MATTMAYO.COM &mdash; TERM v1.0 &mdash; LOGIN OK</p>
+
+    <p class="cmd"><span class="prompt">guest@mattmayo</span><span class="prompt-sym">:~$</span> whoami</p>
+    <div class="whoami">
+      <Image src={headshot} alt="Matt Mayo" width={176} height={176} class="headshot" />
+      <div>
+        <h1 class="name">MATT_MAYO</h1>
+        <p class="title">Senior Engineering Manager // Palo Alto, CA</p>
       </div>
     </div>
-  </section>
 
-  <section class="experience">
-    <h2>Experience</h2>
-    <ol class="timeline">
-      <li>
-        <div class="timeline-header">
-          <h3>Senior Engineering Manager, DrumWave</h3>
-          <span class="dates">2024 &ndash; Present &middot; Mountain View, CA</span>
-        </div>
-        <p>
-          Started as a technical lead on a single 3-engineer team, then moved into managing two
-          teams totaling 13 developers. Lead the build of the core consumer and business
-          experience from 0 to 1.
+    <p class="cmd"><span class="prompt">guest@mattmayo</span><span class="prompt-sym">:~$</span> cat bio.txt</p>
+    <p class="output bio">
+      I build and lead engineering teams that ship fraud detection and infrastructure systems
+      at scale &mdash; from BNPL fraud platforms to globally distributed engineering orgs
+      spanning multiple clouds. I stay hands-on: designing systems, reviewing code, and working
+      directly alongside the teams I lead.
+    </p>
+
+    <p class="cmd"><span class="prompt">guest@mattmayo</span><span class="prompt-sym">:~$</span> open linkedin.lnk</p>
+    <p class="output link">
+      <a href="https://www.linkedin.com/in/mayomatt/" target="_blank" rel="noopener">&rarr; linkedin.com/in/mattmayo</a>
+    </p>
+
+    <p class="cmd"><span class="prompt">guest@mattmayo</span><span class="prompt-sym">:~$</span> ls -la experience/</p>
+    <pre class="listing">2024-now  drw-  DrumWave   Sr. Engineering Manager    Mountain View
+2022-23   drw-  Hipcamp    Sr. Engineering Manager    Remote
+2021-22   drw-  Affirm     Engineering Manager        Remote
+2019-20   drw-  Carta      Engineering Manager        San Francisco
+2016-19   drw-  eBay       Member of Technical Staff  San Francisco
+2014-16   drw-  FiveStars  Lead iPhone Developer      San Francisco
+2010-13   drw-  PayPal     Tech Solutions Architect   San Jose</pre>
+
+    {experience.map((role) => (
+      <>
+        <p class="cmd role-cmd">
+          <span class="prompt">guest@mattmayo</span><span class="prompt-sym">:~$</span> cat experience/{role.slug}.txt
         </p>
-      </li>
-      <li>
-        <div class="timeline-header">
-          <h3>Senior Engineering Manager, Hipcamp</h3>
-          <span class="dates">2022 &ndash; 2023 &middot; Remote</span>
-        </div>
-        <p>
-          Led globally distributed Host experience engineering teams across the US and UK,
-          spanning 3 teams, 10 engineers, and 2 managers. Shipped a new checkout experience and
-          new tooling and integrations for professional campgrounds, including an updated data
-          model to support it. Promoted 2 engineers and moved one into management.
-        </p>
-      </li>
-      <li>
-        <div class="timeline-header">
-          <h3>Engineering Manager, Affirm</h3>
-          <span class="dates">2021 &ndash; 2022 &middot; Remote</span>
-        </div>
-        <p>
-          Led fraud detection for buy now, pay later loans; launched fraud systems into new
-          markets including Australia. Grew the team from 5 to 11 while increasing diversity.
-        </p>
-      </li>
-      <li>
-        <div class="timeline-header">
-          <h3>Engineering Manager, Carta</h3>
-          <span class="dates">2019 &ndash; 2020 &middot; San Francisco, CA</span>
-        </div>
-        <p>
-          Led internal tools and a globally distributed team spanning San Francisco, Toronto,
-          Brazil, and Belarus, including remote hiring and ramp-up across multiple contracting
-          groups. Drove technical design across billing and contract-generation systems.
-        </p>
-      </li>
-      <li>
-        <div class="timeline-header">
-          <h3>Member of Technical Staff, eBay</h3>
-          <span class="dates">2016 &ndash; 2019 &middot; San Francisco, CA</span>
-        </div>
-        <p>
-          Owned a full-stack domain end to end, from data storage through back-end services to
-          front end, deployed on Google Cloud. Led a specialized web shopping experience for the
-          China market and helped set the bar for front-end hiring org-wide.
-        </p>
-      </li>
-      <li>
-        <div class="timeline-header">
-          <h3>Lead iPhone Developer, FiveStars</h3>
-          <span class="dates">2014 &ndash; 2016 &middot; San Francisco, CA</span>
-        </div>
-        <p>
-          Took the FiveStars iOS app from solo project to a team effort, shipping an
-          industry-first check-in experience using Apple's iBeacon framework. Brought the app
-          from a 1-star to 4+ star rating while holding a 99.9% crash-free rate.
-        </p>
-      </li>
-      <li>
-        <div class="timeline-header">
-          <h3>Technical Solutions Architect, PayPal</h3>
-          <span class="dates">2010 &ndash; 2013 &middot; San Jose, CA</span>
-        </div>
-        <p>
-          Led a team of nine engineers to re-platform PayPal's customer-facing reporting
-          infrastructure onto a multi-data-center design serving a 100M+ customer base.
-        </p>
-      </li>
-    </ol>
-  </section>
+        <p class="output detail">{role.detail}</p>
+      </>
+    ))}
+
+    <p class="cmd final">
+      <span class="prompt">guest@mattmayo</span><span class="prompt-sym">:~$</span> <span class="cursor"></span>
+    </p>
+  </div>
 </Layout>
 
 <style>
-  .hero {
+  :global(body) {
+    margin: 0;
+    background: #140d02;
     display: flex;
+    justify-content: center;
+  }
+
+  :global(main) {
+    max-width: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .screen {
+    max-width: 720px;
+    width: 100%;
+    position: relative;
+    padding: 56px 48px 64px;
+    color: #ffb733;
+    font-family: "Share Tech Mono", ui-monospace, monospace;
+  }
+
+  .scanlines {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background-image: repeating-linear-gradient(
+      to bottom,
+      rgba(0, 0, 0, 0) 0,
+      rgba(0, 0, 0, 0) 2px,
+      rgba(0, 0, 0, 0.25) 3px,
+      rgba(0, 0, 0, 0) 4px
+    );
+    mix-blend-mode: multiply;
+  }
+
+  .banner {
+    margin: 0 0 22px;
+    font-size: 13px;
+    color: #cf8c2f;
+  }
+
+  .cmd {
+    margin: 0 0 4px;
+    font-size: 15px;
+  }
+
+  .role-cmd {
+    margin-top: 20px;
+  }
+
+  .prompt {
+    color: #ffd68a;
+  }
+
+  .prompt-sym {
+    color: #cf8c2f;
+  }
+
+  .whoami {
+    display: flex;
+    gap: 20px;
     align-items: center;
-    gap: var(--size-fluid-5);
-    flex-wrap: wrap;
+    margin: 8px 0 28px 16px;
   }
 
-  .photo {
-    width: 200px;
-    height: 200px;
-    border-radius: var(--radius-round);
+  .headshot {
+    width: 88px;
+    height: 88px;
     object-fit: cover;
-    box-shadow: var(--shadow-3);
-    flex-shrink: 0;
+    border: 1px solid #cf8c2f;
+    filter: grayscale(1) contrast(1.3) brightness(0.9) sepia(1) hue-rotate(-10deg) saturate(4);
+    transition: filter 0.35s ease;
+    cursor: pointer;
   }
 
-  .intro {
-    display: flex;
-    flex-direction: column;
-    gap: var(--size-2);
-    min-width: 0;
+  .headshot:hover {
+    filter: none;
   }
 
-  h1 {
-    font-size: var(--font-size-fluid-3);
+  .name {
+    font-family: "VT323", monospace;
+    font-size: 32px;
+    line-height: 1;
+    color: #ffe3b0;
     margin: 0;
+    font-weight: normal;
   }
 
-  .role {
-    font-size: var(--font-size-3);
-    font-weight: var(--font-weight-6);
-    margin: 0;
+  .title {
+    font-size: 14px;
+    color: #cf8c2f;
+    margin: 6px 0 0;
+  }
+
+  .output {
+    margin: 8px 0 28px 16px;
+    color: #e8a94f;
   }
 
   .bio {
-    font-size: var(--font-size-2);
-    color: var(--gray-7);
-    max-width: 55ch;
-    margin: 0;
+    font-size: 14.5px;
+    line-height: 1.6;
   }
 
-  .links {
-    display: flex;
-    gap: var(--size-4);
+  .link {
+    font-size: 14.5px;
   }
 
-  .links a {
-    font-size: var(--font-size-1);
-    font-weight: var(--font-weight-6);
+  .link a {
+    color: #ffe3b0;
   }
 
-  .experience {
-    margin-top: var(--size-fluid-6);
+  .listing {
+    margin: 0 0 6px 16px;
+    font-size: 13.5px;
+    line-height: 1.9;
+    color: #e8a94f;
+    white-space: pre;
+    font-family: inherit;
   }
 
-  .experience h2 {
-    font-size: var(--font-size-fluid-1);
-    margin-block-end: var(--size-4);
+  .detail {
+    font-size: 14px;
+    line-height: 1.6;
+    margin-bottom: 0;
   }
 
-  .timeline {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: var(--size-5);
+  .final {
+    margin-top: 24px;
   }
 
-  .timeline li {
-    border-inline-start: var(--border-size-2) solid var(--gray-4);
-    padding-inline-start: var(--size-4);
+  .cursor {
+    display: inline-block;
+    width: 8px;
+    height: 15px;
+    background: #ffb733;
+    vertical-align: middle;
+    animation: blink 1s step-end infinite;
   }
 
-  .timeline-header {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: baseline;
-    gap: var(--size-2);
-    margin-block-end: var(--size-1);
-  }
-
-  .timeline-header h3 {
-    font-size: var(--font-size-3);
-    margin: 0;
-  }
-
-  .dates {
-    flex-basis: 100%;
-    font-size: var(--font-size-0);
-    color: var(--gray-6);
-  }
-
-  .timeline li p {
-    font-size: var(--font-size-1);
-    color: var(--gray-7);
-    max-width: 65ch;
-    margin: 0;
+  @keyframes blink {
+    0%,
+    49% {
+      opacity: 1;
+    }
+    50%,
+    100% {
+      opacity: 0;
+    }
   }
 
   @media (max-width: 40em) {
-    .hero {
-      flex-direction: column;
-      text-align: center;
+    .screen {
+      padding: 40px 20px 48px;
     }
 
-    .bio {
-      max-width: none;
-    }
-
-    .links {
-      justify-content: center;
-    }
-
-    .timeline-header {
-      flex-direction: column;
-      gap: 0;
+    .whoami {
+      flex-wrap: wrap;
     }
   }
 </style>


### PR DESCRIPTION
## Summary
- Recreates the amber CRT terminal-style design handoff on the homepage: boot banner, `whoami`/`cat bio.txt`/`open linkedin.lnk`/`ls -la experience/` blocks styled as shell commands
- Loads VT323 + Share Tech Mono via Google Fonts for the terminal look
- Adds scanline overlay, headshot amber-monochrome → color hover reveal, and a blinking terminal cursor

## Test plan
- [ ] `npm run dev` and confirm the design matches the handoff reference (colors, spacing, fonts)
- [ ] Verify headshot hover/tap reveals full color
- [ ] Check LinkedIn link opens correctly in a new tab
- [ ] Confirm layout on mobile widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)