### PR TITLE
Document dev server and Open Props gotchas in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,14 @@ astro dev --background
 
 Manage the background server with `astro dev stop`, `astro dev status`, and `astro dev logs`.
 
+If served CSS/markup doesn't reflect recent edits (checked via `curl`), the dev server may be serving a stale HMR cache — run `astro dev stop` then `astro dev --background` again and re-check.
+
+Node is installed via nvm and may not be on the default shell PATH (e.g. `~/.local/share/nvm/v<version>/bin`). If `node`/`npm`/`astro` aren't found, locate the running dev server's binary via `lsof -i :4321` rather than assuming Node isn't installed.
+
+## Styling notes
+
+This project imports `open-props/normalize`, which applies a low-specificity `:where(p){max-inline-size:60ch}` rule to all `<p>` elements. If a paragraph needs to be wider than 60ch, override with `max-inline-size: none` rather than assuming the constraint comes from custom CSS.
+
 ## Documentation
 
 Full documentation: https://docs.astro.build


### PR DESCRIPTION
## Summary
- Notes that a stale HMR cache can make dev-server output not reflect recent CSS/markup edits, and how to fix it (`astro dev stop` + restart)
- Notes that nvm-installed Node may not be on the default shell PATH, and how to locate it via the running dev server
- Notes that Open Props' `normalize` import caps `<p>` width at 60ch by default, and how to override it

## Test plan
- [x] Reviewed diff for accuracy against issues hit during the terminal-homepage redesign session