### PR TITLE
Fix mobile horizontal overflow revealing background bar

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,43 +6,64 @@ import headshot from "../assets/headshot.jpg";
 const experience = [
   {
     slug: "drumwave",
+    dates: "2024-now",
     company: "DrumWave",
+    title: "Sr. Engineering Manager",
+    location: "Mountain View",
     detail:
       "Started as a technical lead on a single 3-engineer team, then moved into managing two teams totaling 13 developers. Leading the build of the core consumer and business experience from 0 to 1.",
   },
   {
     slug: "hipcamp",
+    dates: "2022-23",
     company: "Hipcamp",
+    title: "Sr. Engineering Manager",
+    location: "Remote",
     detail:
       "Led globally distributed Host experience engineering teams across the US and UK, spanning 3 teams, 10 engineers, and 2 managers. Shipped a new checkout experience and new tooling and integrations for professional campgrounds, including an updated data model to support it. Promoted 2 engineers and moved one into management.",
   },
   {
     slug: "affirm",
+    dates: "2021-22",
     company: "Affirm",
+    title: "Engineering Manager",
+    location: "Remote",
     detail:
       "Led fraud detection for buy now, pay later loans; launched fraud systems into new markets including Australia. Grew the team from 5 to 11 while increasing diversity.",
   },
   {
     slug: "carta",
+    dates: "2019-20",
     company: "Carta",
+    title: "Engineering Manager",
+    location: "San Francisco",
     detail:
       "Led internal tools and a globally distributed team spanning San Francisco, Toronto, Brazil, and Belarus, including remote hiring and ramp-up across multiple contracting groups. Drove technical design across billing and contract-generation systems.",
   },
   {
     slug: "ebay",
+    dates: "2016-19",
     company: "eBay",
+    title: "Member of Technical Staff",
+    location: "San Francisco",
     detail:
       "Owned a full-stack domain end to end, from data storage through back-end services to front end, deployed on Google Cloud. Led a specialized web shopping experience for the China market and helped set the bar for front-end hiring org-wide.",
   },
   {
     slug: "fivestars",
+    dates: "2014-16",
     company: "FiveStars",
+    title: "Lead iPhone Developer",
+    location: "San Francisco",
     detail:
       "Took the FiveStars iOS app from solo project to a team effort, shipping an industry-first check-in experience using Apple's iBeacon framework. Brought the app from a 1-star to 4+ star rating while holding a 99.9% crash-free rate.",
   },
   {
     slug: "paypal",
+    dates: "2010-13",
     company: "PayPal",
+    title: "Tech Solutions Architect",
+    location: "San Jose",
     detail:
       "Led a team of nine engineers to re-platform PayPal's customer-facing reporting infrastructure onto a multi-data-center design serving a 100M+ customer base.",
   },
@@ -78,13 +99,17 @@ const experience = [
     </p>
 
     <p class="cmd"><span class="prompt">guest@mattmayo</span><span class="prompt-sym">:~$</span> ls -la experience/</p>
-    <pre class="listing">2024-now  drw-  DrumWave   Sr. Engineering Manager    Mountain View
-2022-23   drw-  Hipcamp    Sr. Engineering Manager    Remote
-2021-22   drw-  Affirm     Engineering Manager        Remote
-2019-20   drw-  Carta      Engineering Manager        San Francisco
-2016-19   drw-  eBay       Member of Technical Staff  San Francisco
-2014-16   drw-  FiveStars  Lead iPhone Developer      San Francisco
-2010-13   drw-  PayPal     Tech Solutions Architect   San Jose</pre>
+    <div class="listing">
+      {experience.map((role) => (
+        <div class="listing-row">
+          <span class="listing-dates">{role.dates}</span>
+          <span class="listing-flag">drw-</span>
+          <span class="listing-company">{role.company}</span>
+          <span class="listing-title">{role.title}</span>
+          <span class="listing-location">{role.location}</span>
+        </div>
+      ))}
+    </div>
 
     {experience.map((role) => (
       <>
@@ -222,13 +247,24 @@ const experience = [
 
   .listing {
     margin: 0 0 6px 16px;
-    max-width: calc(100% - 16px);
-    overflow-x: auto;
     font-size: 13.5px;
     line-height: 1.9;
     color: #e8a94f;
-    white-space: pre;
     font-family: inherit;
+  }
+
+  .listing-row {
+    display: grid;
+    grid-template-columns: 8ch 4ch 9ch 25ch 13ch;
+    column-gap: 2ch;
+  }
+
+  .listing-flag {
+    color: #cf8c2f;
+  }
+
+  .listing-company {
+    color: #ffe3b0;
   }
 
   .detail {
@@ -264,6 +300,33 @@ const experience = [
   @media (max-width: 40em) {
     .whoami {
       flex-wrap: wrap;
+    }
+
+    .listing-row {
+      grid-template-columns: none;
+      grid-template-areas: "dates company" "title title" "location location";
+      column-gap: 8px;
+      margin-bottom: 10px;
+    }
+
+    .listing-dates {
+      grid-area: dates;
+    }
+
+    .listing-flag {
+      display: none;
+    }
+
+    .listing-company {
+      grid-area: company;
+    }
+
+    .listing-title {
+      grid-area: title;
+    }
+
+    .listing-location {
+      grid-area: location;
     }
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -102,11 +102,16 @@ const experience = [
 </Layout>
 
 <style>
+  :global(html) {
+    background: #140d02;
+  }
+
   :global(body) {
     margin: 0;
     background: #140d02;
     display: flex;
     justify-content: center;
+    overflow-x: hidden;
   }
 
   :global(main) {
@@ -217,6 +222,8 @@ const experience = [
 
   .listing {
     margin: 0 0 6px 16px;
+    max-width: calc(100% - 16px);
+    overflow-x: auto;
     font-size: 13.5px;
     line-height: 1.9;
     color: #e8a94f;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -124,7 +124,7 @@ const experience = [
     max-width: 720px;
     width: 100%;
     position: relative;
-    padding: clamp(40px, 7vw, 56px) clamp(20px, 6vw, 48px) clamp(48px, 8vw, 64px);
+    padding: clamp(40px, 7.7778vw, 56px) clamp(20px, 6.6667vw, 48px) clamp(48px, 8.8889vw, 64px);
     color: #ffb733;
     font-family: "Share Tech Mono", ui-monospace, monospace;
   }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -121,10 +121,12 @@ const experience = [
   }
 
   .screen {
+    container-type: inline-size;
+    box-sizing: border-box;
     max-width: 720px;
     width: 100%;
     position: relative;
-    padding: clamp(40px, 7vw, 56px) clamp(20px, 6vw, 48px) clamp(48px, 8vw, 64px);
+    padding: clamp(40px, 7cqw, 56px) clamp(20px, 6cqw, 48px) clamp(48px, 8cqw, 64px);
     color: #ffb733;
     font-family: "Share Tech Mono", ui-monospace, monospace;
   }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -124,7 +124,7 @@ const experience = [
     max-width: 720px;
     width: 100%;
     position: relative;
-    padding: 56px 48px 64px;
+    padding: clamp(40px, 7vw, 56px) clamp(20px, 6vw, 48px) clamp(48px, 8vw, 64px);
     color: #ffb733;
     font-family: "Share Tech Mono", ui-monospace, monospace;
   }
@@ -262,10 +262,6 @@ const experience = [
   }
 
   @media (max-width: 40em) {
-    .screen {
-      padding: 40px 20px 48px;
-    }
-
     .whoami {
       flex-wrap: wrap;
     }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -121,12 +121,10 @@ const experience = [
   }
 
   .screen {
-    container-type: inline-size;
-    box-sizing: border-box;
     max-width: 720px;
     width: 100%;
     position: relative;
-    padding: clamp(40px, 7cqw, 56px) clamp(20px, 6cqw, 48px) clamp(48px, 8cqw, 64px);
+    padding: clamp(40px, 7vw, 56px) clamp(20px, 6vw, 48px) clamp(48px, 8vw, 64px);
     color: #ffb733;
     font-family: "Share Tech Mono", ui-monospace, monospace;
   }


### PR DESCRIPTION
## Summary
- The `ls -la experience/` listing (`white-space: pre`) is wider than narrow mobile viewports, which pushed the whole `.screen` wider than the page and revealed the browser's default background as a vertical bar on the right when scrolled
- Scoped the overflow to the listing block itself (`overflow-x: auto`, capped width) instead of letting it widen the page
- Added `overflow-x: hidden` on `body` and a matching `background` on `html` as a safety net so any future overflow doesn't expose a mismatched background

## Test plan
- [ ] Load the site on a narrow mobile viewport (or emulate one in devtools) and confirm no vertical bar / horizontal scroll on the page
- [ ] Confirm the `ls -la` listing still scrolls horizontally within its own block if content is too wide