### PR TITLE
Widen screen container, resize headshot, add CRT flicker animation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,22 @@ Node is installed via nvm and may not be on the default shell PATH (e.g. `~/.loc
 
 This project imports `open-props/normalize`, which applies a low-specificity `:where(p){max-inline-size:60ch}` rule to all `<p>` elements. If a paragraph needs to be wider than 60ch, override with `max-inline-size: none` rather than assuming the constraint comes from custom CSS.
 
+## `.screen` container width and padding
+
+`.screen`'s `max-width` and its `clamp()`-based padding are tuned together on purpose:
+
+- The vertical/right-edge-style paddings (top, bottom) use `clamp(min, Xvw, max)` where `X = max_px / (screen_max_width_px / 100)`. This makes the padding hit its ceiling at exactly the same viewport width where `.screen` itself stops growing (currently 900px), so padding and container width scale in lockstep below that width and both go flat above it. If `.screen`'s `max-width` changes, recompute these `vw` percentages to match, or the padding will keep growing (or stop growing) at the wrong width relative to the container.
+- The left/right padding is intentionally inverted: it's flat at 20px through mobile widths (≤640px, matching the `.listing-row` stacking breakpoint), tapers linearly to 0px between 640px and 900px, then stays flat at 0px above 900px. This uses `clamp(0px, calc(A - Bvw), 20px)` rather than a plain `Xvw` — the `calc()` intentionally decreases as viewport grows, which is the opposite direction from the top/bottom padding. Don't "simplify" this back to a normal `clamp(min, Xvw, max)` — the inversion is the point.
+
+## Headshot flicker animation
+
+The headshot's amber-to-color reveal (`@keyframes headshot-reveal` on `.headshot`) is built to look like an old CRT struggling to hold a picture, not a smooth crossfade:
+
+- Uses `steps(1, jump-end)` as the timing function, not `ease`, so the filter snaps instantly between keyframes instead of fading — that's what makes it read as "flicker" rather than "dissolve."
+- The keyframe percentages encode absolute real-time offsets relative to the animation's total duration. Whenever the total duration changes (currently 30s), every keyframe percentage must be rescaled (`old_seconds / new_duration_seconds * 100`) to preserve the actual flicker timing (short on/off stutter, ~1.2s clear hold, short stutter back to amber). Don't just change the duration and leave percentages as-is, or the flicker will compress/stretch unintentionally.
+- `animation-delay` on the shorthand only delays the *first* iteration; with `infinite`, later cycles repeat back-to-back at the animation's own duration with no extra gap. This is why delay = duration (30s) currently gives "wait 30s, then flicker every 30s" rather than needing separate logic.
+- Manual hover is kept independent of the loop: `.headshot:hover` sets `animation: none; filter: none;` — using `none` (not just overriding `filter`) avoids the animation's per-frame filter value fighting with the hover rule, since CSS animations otherwise take priority over normal declarations on the same property.
+
 ## Documentation
 
 Full documentation: https://docs.astro.build

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -78,7 +78,7 @@ const experience = [
 
     <p class="cmd"><span class="prompt">guest@mattmayo</span><span class="prompt-sym">:~$</span> whoami</p>
     <div class="whoami">
-      <Image src={headshot} alt="Matt Mayo" width={176} height={176} class="headshot" />
+      <Image src={headshot} alt="Matt Mayo" width={528} height={528} class="headshot" />
       <div>
         <h1 class="name">MATT_MAYO</h1>
         <p class="title">Senior Engineering Manager // Palo Alto, CA</p>
@@ -146,10 +146,10 @@ const experience = [
   }
 
   .screen {
-    max-width: 720px;
+    max-width: 900px;
     width: 100%;
     position: relative;
-    padding: clamp(40px, 7.7778vw, 56px) clamp(20px, 6.6667vw, 48px) clamp(48px, 8.8889vw, 64px);
+    padding: clamp(40px, 6.2222vw, 56px) clamp(0px, calc(69.2308px - 7.6923vw), 20px) clamp(48px, 7.1111vw, 64px);
     color: #ffb733;
     font-family: "Share Tech Mono", ui-monospace, monospace;
   }
@@ -193,23 +193,46 @@ const experience = [
 
   .whoami {
     display: flex;
+    flex-direction: column;
     gap: 20px;
-    align-items: center;
+    align-items: flex-start;
     margin: 8px 0 28px 16px;
   }
 
   .headshot {
-    width: 88px;
-    height: 88px;
+    width: 264px;
+    height: 264px;
     object-fit: cover;
     border: 1px solid #cf8c2f;
     filter: grayscale(1) contrast(1.3) brightness(0.9) sepia(1) hue-rotate(-10deg) saturate(4);
     transition: filter 0.35s ease;
     cursor: pointer;
+    animation: headshot-reveal 30s steps(1, jump-end) 30s infinite;
   }
 
   .headshot:hover {
+    animation: none;
     filter: none;
+  }
+
+  @keyframes headshot-reveal {
+    0%,
+    0.4333%,
+    0.8%,
+    5.1333%,
+    5.4333%,
+    5.7333%,
+    100% {
+      filter: grayscale(1) contrast(1.3) brightness(0.9) sepia(1) hue-rotate(-10deg) saturate(4);
+    }
+    0.2667%,
+    0.6333%,
+    1.0667%,
+    5%,
+    5.3%,
+    5.6% {
+      filter: none;
+    }
   }
 
   .name {


### PR DESCRIPTION
## Summary
- Bumps `.screen` max-width from 720px to 900px, rescaling the padding clamp so it still hits its ceiling exactly at the new width
- Inverts the left/right padding: flat 20px through mobile, tapering to 0px between 640-900px viewport widths, edge-to-edge above that
- Triples the headshot size and stacks name/title below it instead of beside it
- Replaces the hover-only color reveal with a looping CRT-style flicker (30s cycle, 30s initial delay, `steps()` timing for a snap rather than fade), while keeping manual hover independent of the loop

## Notes
Documented the padding-scaling and animation-timing mechanics in AGENTS.md for future iteration.